### PR TITLE
[requirements] pin pyinstaller to v4.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 PyQt5
 fontTools
-https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz
+# https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz
+pyinstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ altgraph==0.17            # via macholib, pyinstaller
 fonttools==4.21.1         # via -r requirements.in
 macholib==1.14            # via pyinstaller
 pyinstaller-hooks-contrib==2021.1  # via pyinstaller
-https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz  # via -r requirements.in
+pyinstaller==4.2          # via -r requirements.in
 pyqt5-qt5==5.15.2         # via pyqt5
 pyqt5-sip==12.8.1         # via pyqt5
 pyqt5==5.15.3             # via -r requirements.in


### PR DESCRIPTION
Pins the macOS/Win CI tested and release pyinstaller version to 4.2